### PR TITLE
Workflow Upgrades and Add Google Drive Upload

### DIFF
--- a/.github/workflows/PDF_upload_artifacts.yml
+++ b/.github/workflows/PDF_upload_artifacts.yml
@@ -1,4 +1,4 @@
-name: Build examples
+name: Upload PDF to GitHub artifacts
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/PDF_upload_gdrive.yml
+++ b/.github/workflows/PDF_upload_gdrive.yml
@@ -1,0 +1,30 @@
+name: Upload PDF to Google Drive
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build-examples:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Install dependencies
+          run: apk update && apk add texmf-dist texlive texmf-dist-latexextra nodejs
+
+        - name: Set PDF Filename
+          id: set_filename
+          run: echo "::set-output name=pdf_filename::utc_article_$(date +'%d-%m-%Y')"
+
+        - name: Build examples
+          run: cp -r utc-*/* examples && cd examples && pdflatex -interaction=nonstopmode -halt-on-error -jobname="${{ steps.set_filename.outputs.pdf_filename }}" utc-*.tex
+
+        - name: Upload PDF TO Google Drive
+          uses: Jumbo810/Upload_Github_Artifacts_TO_GDrive@v2.2.2
+          with:
+            target: examples/${{ steps.set_filename.outputs.pdf_filename }}.pdf
+            credentials: ${{ secrets.GDRIVE_TOKEN }}
+            parent_folder_id: ${{ secrets.GDRIVE_FOLDER }}
+            override: true

--- a/.github/workflows/PDF_upload_release.yml
+++ b/.github/workflows/PDF_upload_release.yml
@@ -44,7 +44,7 @@ jobs:
         run: mkdir public && echo "<!DOCTYPE html><html lang='fr'><head><meta charset='UTF-8'><meta http-equiv='refresh' content='0;url=./utc-article.pdf'><title>Redirection vers le PDF</title></head></html>" > public/index.html
 
       - name: Move PDFs
-        run: mv example/utc-example.pdf public
+        run: mv examples/utc-example.pdf public
 
       - name: Deploy to Pages
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/PDF_upload_release.yml
+++ b/.github/workflows/PDF_upload_release.yml
@@ -44,7 +44,7 @@ jobs:
         run: mkdir public && echo "<!DOCTYPE html><html lang='fr'><head><meta charset='UTF-8'><meta http-equiv='refresh' content='0;url=./utc-article.pdf'><title>Redirection vers le PDF</title></head></html>" > public/index.html
 
       - name: Move PDFs
-        run: mv examples/utc-example.pdf public
+        run: mv examples/utc-article.pdf public
 
       - name: Deploy to Pages
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/PDF_upload_release.yml
+++ b/.github/workflows/PDF_upload_release.yml
@@ -1,0 +1,41 @@
+name: Upload when release
+on:
+  push:
+    tags:
+      - '*.*.*'
+jobs:
+  build-examples:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: apk update && apk add texmf-dist texlive texmf-dist-latexextra nodejs
+
+      - name: Build examples
+        run: cp -r utc-*/* examples && cd examples && pdflatex -interaction=nonstopmode -halt-on-error utc-*.tex
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.CICD_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.CICD_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: examples/utc-article.pdf
+          asset_name: utc-article-example.pdf
+          asset_content_type: pdf

--- a/.github/workflows/PDF_upload_release.yml
+++ b/.github/workflows/PDF_upload_release.yml
@@ -1,4 +1,4 @@
-name: Upload when release
+name: Upload when release and Update Pages
 on:
   push:
     tags:
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: apk update && apk add texmf-dist texlive texmf-dist-latexextra nodejs
+        run: apk update && apk add texmf-dist texlive texmf-dist-latexextra nodejs git-lfs git
 
       - name: Build examples
-        run: cp -r utc-*/* examples && cd examples && pdflatex -interaction=nonstopmode -halt-on-error utc-*.tex
+        run: cp -r utc-*/* examples && cd examples && pdflatex -interaction=nonstopmode -halt-on-error utc-*.tex && cd ..
 
       - name: Create Release
         id: create_release
@@ -39,3 +39,18 @@ jobs:
           asset_path: examples/utc-article.pdf
           asset_name: utc-article-example.pdf
           asset_content_type: pdf
+
+      - name: Create index.html
+        run: mkdir public && echo "<!DOCTYPE html><html lang='fr'><head><meta charset='UTF-8'><meta http-equiv='refresh' content='0;url=./utc-article.pdf'><title>Redirection vers le PDF</title></head></html>" > public/index.html
+
+      - name: Move PDFs
+        run: mv example/utc-example.pdf public
+
+      - name: Deploy to Pages
+        uses: peaceiris/actions-gh-pages@v3.8.0
+        with:
+          personal_token: ${{ secrets.CICD_TOKEN }}
+          publish_dir: public
+          allow_empty_commit: true
+          force_orphan: true
+          enable_jekyll: true


### PR DESCRIPTION
# V1.1.3
_by_ [Hugo](https://github.com/tigrou23) 🐯
___
This release concerns GitHub Action part (CI/CD). Two features has been released : 
- GDrive Export
- Release Export

## GDrive Export
When a push is performed, the GDrive workflow start. The PDF is generated and sent over your Google Drive repository. Please create secrets : _Settings --> Actions secrets and variables --> New repository secret_. 

⚠️ You must name the secrets like that : 
- **GDRIVE_TOKEN**
- **GDRIVE_FOLDER**

### GDRIVE_TOKEN content
[Generate and download your credentials in JSON format](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys)

Run base64 my_service_account_key.json > encoded.txt and paste the encoded string into a github secret (**named GDRIVE_TOKEN**).

### GDRIVE_FOLDER content
The id of the drive folder where you want to upload your file. It is the string of characters after the last / when browsing to your folder URL. You must share the folder with the service account (using its email address) unless you specify a owner. **Please notice that the secret has to be named with GDRIVE_TOKEN**.

## Release Export
When a tag is put, the release workflow start. A snapshot of the repository, including the generated PDF is upload into the Release section. Please create a secret with : _Settings --> Actions secrets and variables --> New repository secret_. 

⚠️ You must name the secret like that : **CICD_TOKEN**

The value of this secret is a [GitHub Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) of your account. 